### PR TITLE
add consumer group instance id to suport KIP-345

### DIFF
--- a/faust/transport/drivers/aiokafka.py
+++ b/faust/transport/drivers/aiokafka.py
@@ -496,7 +496,7 @@ class AIOKafkaConsumerThread(ConsumerThread):
             api_version=conf.consumer_api_version,
             client_id=conf.broker_client_id,
             group_id=conf.id,
-            # group_instance_id=conf.consumer_group_instance_id,
+            group_instance_id=conf.consumer_group_instance_id,
             bootstrap_servers=server_list(transport.url, transport.default_port),
             partition_assignment_strategy=[self._assignor],
             enable_auto_commit=False,


### PR DESCRIPTION
## Description

This adds KIP-345 to faust.