### PR TITLE
Sx global global tables

### DIFF
--- a/faust/app/base.py
+++ b/faust/app/base.py
@@ -1220,7 +1220,7 @@ class App(AppT, Service):
                     # as they come min (using 1 buffer size).
                     standby_buffer_size=1,
                     is_global=True,
-                    is_global_global=False,
+                    synchronize_all_active_partitions=False,
                     help=help,
                     **kwargs,
                 ),

--- a/faust/app/base.py
+++ b/faust/app/base.py
@@ -1186,6 +1186,7 @@ class App(AppT, Service):
         window: Optional[WindowT] = None,
         partitions: Optional[int] = None,
         help: Optional[str] = None,
+        synchronize_all_active_partitions: Optional[bool] = False,
         **kwargs: Any,
     ) -> GlobalTableT:
         """Define new global table.
@@ -1220,7 +1221,7 @@ class App(AppT, Service):
                     # as they come min (using 1 buffer size).
                     standby_buffer_size=1,
                     is_global=True,
-                    synchronize_all_active_partitions=False,
+                    synchronize_all_active_partitions=synchronize_all_active_partitions,
                     help=help,
                     **kwargs,
                 ),

--- a/faust/app/base.py
+++ b/faust/app/base.py
@@ -1220,56 +1220,7 @@ class App(AppT, Service):
                     # as they come min (using 1 buffer size).
                     standby_buffer_size=1,
                     is_global=True,
-                    help=help,
-                    **kwargs,
-                ),
-            )
-        )
-        return cast(GlobalTableT, gtable.using_window(window) if window else gtable)
-
-    def GlobalGlobalTable(
-        self,
-        name: str,
-        *,
-        default: Callable[[], Any] = None,
-        window: Optional[WindowT] = None,
-        partitions: Optional[int] = None,
-        help: Optional[str] = None,
-        **kwargs: Any,
-    ) -> GlobalTableT:
-        """Define new global table.
-
-        Arguments:
-            name: Name used for global table, note that two global tables
-                living in the same application cannot have the same name.
-
-            default: A callable, or type that will return a default valu
-               for keys missing in this global table.
-            window: A windowing strategy to wrap this window in.
-
-        Examples:
-            >>> gtable = app.GlobalTable('user_to_amount', default=int)
-            >>> gtable['George']
-            0
-            >>> gtable['Elaine'] += 1
-            >>> gtable['Elaine'] += 1
-            >>> gtable['Elaine']
-            2
-        """
-        gtable = self.tables.add(
-            cast(
-                GlobalTableT,
-                self.conf.GlobalTable(  # type: ignore
-                    self,
-                    name=name,
-                    default=default,
-                    beacon=self.tables.beacon,
-                    partitions=partitions,
-                    # we want to apply standby changes
-                    # as they come min (using 1 buffer size).
-                    standby_buffer_size=1,
-                    is_global=True,
-                    is_global_global=True,
+                    is_global_global=False,
                     help=help,
                     **kwargs,
                 ),

--- a/faust/assignor/partition_assignor.py
+++ b/faust/assignor/partition_assignor.py
@@ -338,7 +338,7 @@ class PartitionAssignor(AbstractPartitionAssignor, PartitionAssignorT):  # type:
                     # shared state over multiple consumer groups.
                     if (
                         table.synchronize_all_active_partitions
-                        or self.table.use_partitioner
+                        or table.use_partitioner
                     ):
                         standby_partitions = all_partitions
                     else:  # Only add those partitions as standby which aren't active

--- a/faust/assignor/partition_assignor.py
+++ b/faust/assignor/partition_assignor.py
@@ -327,7 +327,10 @@ class PartitionAssignor(AbstractPartitionAssignor, PartitionAssignorT):  # type:
                         assignment.actives.get(changelog_topic_name, [])
                     )
                     # Only add those partitions as standby which aren't active
-                    standby_partitions = all_partitions - active_partitions
+                    if not table.is_global_global:
+                        standby_partitions = all_partitions - active_partitions
+                    else:
+                        standby_partitions = all_partitions
                     assignment.standbys[changelog_topic_name] = list(standby_partitions)
                     # We add all_partitions as active so they are recovered
                     # in the beginning.

--- a/faust/assignor/partition_assignor.py
+++ b/faust/assignor/partition_assignor.py
@@ -328,16 +328,20 @@ class PartitionAssignor(AbstractPartitionAssignor, PartitionAssignorT):  # type:
                     )
                     
                     # if we use_partitioner it could happen that we write in Worker A
-                    # to a partitions which is not active in Worker A but active in Worker B.
-                    # To let Worker B consume the update we have to have all_partitions as
-                    # standbys as well.
-                    # A similar situation is happening if Global tables are shared over 
-                    # multiple consumer groups. Consumer group A could write to the table
-                    # and consumer group B, C, D only consuming. With the global_global flag it's
-                    # possible to have shared state over multiple consumer groups.
-                    if table.is_global_global or self.table.use_partitioner:
+                    # to a partitions which is not active in Worker A but active in
+                    # Worker B. To let Worker B consume the update we have to have
+                    # all_partitions as standbys as well.
+                    # A similar situation is happening if Global tables are shared
+                    # over multiple consumer groups. Consumer group A could write to
+                    # the table and consumer group B, C, D only consuming. With the
+                    # synchronize_all_active_partitions flag it's possible to have
+                    # shared state over multiple consumer groups.
+                    if (
+                        table.synchronize_all_active_partitions
+                        or self.table.use_partitioner
+                    ):
                         standby_partitions = all_partitions
-                    else: # Only add those partitions as standby which aren't active
+                    else:  # Only add those partitions as standby which aren't active
                         standby_partitions = all_partitions - active_partitions
                     assignment.standbys[changelog_topic_name] = list(standby_partitions)
                     # We add all_partitions as active so they are recovered

--- a/faust/assignor/partition_assignor.py
+++ b/faust/assignor/partition_assignor.py
@@ -326,7 +326,7 @@ class PartitionAssignor(AbstractPartitionAssignor, PartitionAssignorT):  # type:
                     active_partitions = set(
                         assignment.actives.get(changelog_topic_name, [])
                     )
-                    
+
                     # if we use_partitioner it could happen that we write in Worker A
                     # to a partitions which is not active in Worker A but active in
                     # Worker B. To let Worker B consume the update we have to have

--- a/faust/tables/base.py
+++ b/faust/tables/base.py
@@ -122,6 +122,7 @@ class Collection(Service, CollectionT):
         use_partitioner: bool = False,
         on_window_close: Optional[WindowCloseCallback] = None,
         is_global: bool = False,
+        is_global_global: bool = False,
         **kwargs: Any,
     ) -> None:
         Service.__init__(self, **kwargs)
@@ -144,6 +145,7 @@ class Collection(Service, CollectionT):
         self._on_window_close = on_window_close
         self.last_closed_window = 0.0
         self.is_global = is_global
+        self.is_global_global = is_global_global
         assert self.recovery_buffer_size > 0 and self.standby_buffer_size > 0
 
         self.options = options

--- a/faust/tables/base.py
+++ b/faust/tables/base.py
@@ -122,7 +122,7 @@ class Collection(Service, CollectionT):
         use_partitioner: bool = False,
         on_window_close: Optional[WindowCloseCallback] = None,
         is_global: bool = False,
-        is_global_global: bool = False,
+        synchronize_all_active_partitions: bool = False,
         **kwargs: Any,
     ) -> None:
         Service.__init__(self, **kwargs)
@@ -145,7 +145,9 @@ class Collection(Service, CollectionT):
         self._on_window_close = on_window_close
         self.last_closed_window = 0.0
         self.is_global = is_global
-        self.is_global_global = is_global_global
+        self.synchronize_all_active_partitions = synchronize_all_active_partitions
+        if self.synchronize_all_active_partitions:
+            assert self.is_global
         assert self.recovery_buffer_size > 0 and self.standby_buffer_size > 0
 
         self.options = options

--- a/tests/unit/stores/test_rocksdb.py
+++ b/tests/unit/stores/test_rocksdb.py
@@ -280,6 +280,7 @@ class Test_Store:
         db.get.return_value = b"value"
         store.table = Mock(name="table")
         store.table.is_global = False
+        store.table.is_global_global = False
         store.table.use_partitioner = False
 
         assert store._get(b"key") == b"value"
@@ -312,6 +313,7 @@ class Test_Store:
 
         store.table = Mock(name="table")
         store.table.is_global = False
+        store.table.is_global_global = False
         store.table.use_partitioner = False
 
         # A _get call from a stream, to a non-global, non-partitioner, table
@@ -320,6 +322,14 @@ class Test_Store:
         assert store._get(b"key") is None
 
         store.table.is_global = True
+        store.table.is_global_global = True
+        store.table.use_partitioner = False
+
+        # A global table ignores the event partition and pulls from the proper db
+        assert store._get(b"key") == b"value"
+
+        store.table.is_global = False
+        store.table.is_global_global = True
         store.table.use_partitioner = False
 
         # A global table ignores the event partition and pulls from the proper db
@@ -600,6 +610,11 @@ class Test_Store:
 
         # Global Table
         table.is_global = True
+        assert list(store._dbs_for_actives()) == [dbs[1], dbs[2], dbs[3]]
+
+        # Global Global Table
+        table.is_global = True
+        table.is_global_global = True
         assert list(store._dbs_for_actives()) == [dbs[1], dbs[2], dbs[3]]
 
     def test__size(self, *, store):

--- a/tests/unit/stores/test_rocksdb.py
+++ b/tests/unit/stores/test_rocksdb.py
@@ -280,7 +280,7 @@ class Test_Store:
         db.get.return_value = b"value"
         store.table = Mock(name="table")
         store.table.is_global = False
-        store.table.is_global_global = False
+        store.table.synchronize_all_active_partitions = False
         store.table.use_partitioner = False
 
         assert store._get(b"key") == b"value"
@@ -313,7 +313,7 @@ class Test_Store:
 
         store.table = Mock(name="table")
         store.table.is_global = False
-        store.table.is_global_global = False
+        store.table.synchronize_all_active_partitions = False
         store.table.use_partitioner = False
 
         # A _get call from a stream, to a non-global, non-partitioner, table
@@ -322,7 +322,7 @@ class Test_Store:
         assert store._get(b"key") is None
 
         store.table.is_global = True
-        store.table.is_global_global = True
+        store.table.synchronize_all_active_partitions = True
         store.table.use_partitioner = False
 
         # A global table ignores the event partition and pulls from the proper db
@@ -614,7 +614,7 @@ class Test_Store:
 
         # Global Global Table
         table.is_global = True
-        table.is_global_global = True
+        table.synchronize_all_active_partitions = True
         assert list(store._dbs_for_actives()) == [dbs[1], dbs[2], dbs[3]]
 
     def test__size(self, *, store):


### PR DESCRIPTION
If we use_partitioner and global tables it could happen that we write in Worker A to a partitions which is not active in Worker A but active in Worker B. To let Worker B consume the update we have to have all_partitions as standbys as well.

A similar situation is happening if Global tables are shared over multiple consumer groups by using the possibility to pass a topic that should be used as changelog to the table. Consumer group A could write to the table and consumer group B, C, D only consuming. With the global_global flag it's possible to have shared state over multiple consumer groups.

As a side note. I'm happy if someone has better naming suggestions of the attribute :).