### PR TITLE
changed self.table to table

### DIFF
--- a/faust/assignor/partition_assignor.py
+++ b/faust/assignor/partition_assignor.py
@@ -338,7 +338,7 @@ class PartitionAssignor(AbstractPartitionAssignor, PartitionAssignorT):  # type:
                     # shared state over multiple consumer groups.
                     if (
                         table.synchronize_all_active_partitions
-                        or self.table.use_partitioner
+                        or table.use_partitioner
                     ):
                         standby_partitions = all_partitions
                     else:  # Only add those partitions as standby which aren't active


### PR DESCRIPTION

## Description

The `PartitionAssignor()` class has no attribute `self.table`. This error caused the all applications using a table with `is_global=True` and specifying `synchronize_all_active_partitions=True` to stuck  at leader_election. I wasn't able to figure out this behavior occurred but this PR should solve the problem!

