### PR TITLE
Faster bigtable startup revokes

### DIFF
--- a/faust/stores/bigtable.py
+++ b/faust/stores/bigtable.py
@@ -605,6 +605,7 @@ class BigTableStore(base.SerializedStore):
             if partition in self._startup_cache:
                 self._startup_cache[partition].clear()
                 del self._startup_cache[partition]
+        gc.collect()
         self.log.info(f"Revoking partitions {partitions} for {table.name}")
 
     async def on_rebalance(

--- a/faust/stores/bigtable.py
+++ b/faust/stores/bigtable.py
@@ -239,6 +239,12 @@ class BigTableStore(base.SerializedStore):
     def _set_cache(self, partition: int, key: bytes, value):
         if not self._startup_cache_enable:
             return
+        if partition not in self._startup_cache:
+            self.log.warning(
+                f"Had to manually create partition {partition} for "
+                f"_startup_cache in table {self.table.name}"
+            )
+            self._startup_cache[partition] = {}
         self._startup_cache[partition][key] = value
 
     def _get_cache(self, partition: int, key: bytes):

--- a/faust/stores/bigtable.py
+++ b/faust/stores/bigtable.py
@@ -373,10 +373,6 @@ class BigTableStore(base.SerializedStore):
             if partitions is None:
                 partitions = self._active_partitions()
             row_set = BT.RowSet()
-            self.log.info(
-                f"BigtableStore: Iterating over {len(partitions)} partitions "
-                f"for table {self.table_name}"
-            )
 
             need_all_keys = self.table.is_global or self.table.use_partitioner
             if not need_all_keys:

--- a/faust/stores/bigtable.py
+++ b/faust/stores/bigtable.py
@@ -240,11 +240,9 @@ class BigTableStore(base.SerializedStore):
         if not self._startup_cache_enable:
             return
         if partition not in self._startup_cache:
-            self.log.warning(
-                f"Had to manually create partition {partition} for "
-                f"_startup_cache in table {self.table.name}"
-            )
-            self._startup_cache[partition] = {}
+            # This means, that the startup cache is not activated
+            # for this partition
+            return
         self._startup_cache[partition][key] = value
 
     def _get_cache(self, partition: int, key: bytes):
@@ -591,10 +589,6 @@ class BigTableStore(base.SerializedStore):
         # Fill cache with all keys for the partitions we are assigned
         partitions = self._get_active_changelogtopic_partitions(table, tps)
         self.log.info(f"Assigning partitions {partitions} for {table.name}")
-        if self._startup_cache_enable:
-            for p in partitions:
-                if p not in self._startup_cache:
-                    self._startup_cache[p] = {}
 
     def revoke_partitions(self, table: CollectionT, tps: Set[TP]) -> None:
         partitions = set()

--- a/faust/stores/bigtable.py
+++ b/faust/stores/bigtable.py
@@ -585,6 +585,10 @@ class BigTableStore(base.SerializedStore):
         # Fill cache with all keys for the partitions we are assigned
         partitions = self._get_active_changelogtopic_partitions(table, tps)
         self.log.info(f"Assigning partitions {partitions} for {table.name}")
+        if self._startup_cache_enable:
+            for p in partitions:
+                if p not in self._startup_cache:
+                    self._startup_cache[p] = {}
 
     def revoke_partitions(self, table: CollectionT, tps: Set[TP]) -> None:
         partitions = set()


### PR DESCRIPTION
- Changed startup cache to 2 level index with partition and key
- Improved partition revoke and assign to be faster
   The filling of the cache happens after the recovery is completed. Therfor rebalance don't happen that often anymore.

- Adjusted tests accoring to changes
- Added tests for on_recovery_complete