### PR TITLE
Chore/use faust assignore if changelogtopics

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -46,7 +46,7 @@ jobs:
         use-cython: ['true', 'false']
         experimental: [false]
         include:
-          - python-version: 'pypy3.9'
+          - python-version: 'pypy3.11'
             use-cython: false
             experimental: true
     env:

--- a/faust/__init__.py
+++ b/faust/__init__.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
 """Python Stream processing."""
+
 # :copyright: (c) 2017-2020, Robinhood Markets, Inc.
 #             All rights reserved.
 # :license:   BSD (3 Clause), see LICENSE for more details.

--- a/faust/stores/aerospike.py
+++ b/faust/stores/aerospike.py
@@ -98,7 +98,7 @@ class AeroSpikeStore(base.SerializedStore):
         key = (self.namespace, self.table_name, key)
         fun = self.client.get
         try:
-            (key, meta, bins) = self.aerospike_fun_call_with_retry(fun=fun, key=key)
+            key, meta, bins = self.aerospike_fun_call_with_retry(fun=fun, key=key)
             if bins:
                 return bins[self.BIN_KEY]
             return None
@@ -173,7 +173,7 @@ class AeroSpikeStore(base.SerializedStore):
                 fun=fun, namespace=self.namespace, set=self.table_name
             )
             for result in scan.results():
-                (key, meta, bins) = result
+                key, meta, bins = result
                 if bins:
                     yield bins[self.BIN_KEY]
                 else:
@@ -193,8 +193,8 @@ class AeroSpikeStore(base.SerializedStore):
                 fun=fun, namespace=self.namespace, set=self.table_name
             )
             for result in scan.results():
-                (key_data, meta, bins) = result
-                (ns, set, policy, key) = key_data
+                key_data, meta, bins = result
+                ns, set, policy, key = key_data
 
                 if bins:
                     bins = bins[self.BIN_KEY]
@@ -214,7 +214,7 @@ class AeroSpikeStore(base.SerializedStore):
         try:
             if self.app.conf.store_check_exists:
                 key = (self.namespace, self.table_name, key)
-                (key, meta) = self.aerospike_fun_call_with_retry(
+                key, meta = self.aerospike_fun_call_with_retry(
                     fun=self.client.exists, key=key
                 )
                 if meta:

--- a/faust/transport/drivers/aiokafka.py
+++ b/faust/transport/drivers/aiokafka.py
@@ -27,9 +27,6 @@ from typing import (
 import aiokafka
 import aiokafka.abc
 import opentracing
-from packaging.version import Version
-
-_AIOKAFKA_HAS_API_VERSION = Version(aiokafka.__version__) < Version("0.13.0")
 from aiokafka import TopicPartition
 from aiokafka.consumer.group_coordinator import OffsetCommitRequest
 from aiokafka.coordinator.assignors.roundrobin import RoundRobinPartitionAssignor

--- a/faust/transport/drivers/aiokafka.py
+++ b/faust/transport/drivers/aiokafka.py
@@ -27,9 +27,6 @@ from typing import (
 import aiokafka
 import aiokafka.abc
 import opentracing
-from packaging.version import Version
-
-_AIOKAFKA_HAS_API_VERSION = Version(aiokafka.__version__) < Version("0.13.0")
 from aiokafka import TopicPartition
 from aiokafka.consumer.group_coordinator import OffsetCommitRequest
 from aiokafka.coordinator.assignors.roundrobin import RoundRobinPartitionAssignor
@@ -45,7 +42,7 @@ from aiokafka.errors import (
 )
 from aiokafka.partitioner import DefaultPartitioner, murmur2
 from aiokafka.protocol.admin import CreateTopicsRequest
-from aiokafka.protocol.metadata import MetadataRequest_v1
+from aiokafka.protocol.metadata import MetadataRequest
 from aiokafka.structs import OffsetAndMetadata, TopicPartition as _TopicPartition
 from aiokafka.util import parse_kafka_version
 from mode import Service, get_logger
@@ -55,6 +52,7 @@ from mode.utils.futures import StampedeWrapper
 from mode.utils.objects import cached_property
 from mode.utils.times import Seconds, humanize_seconds_ago, want_seconds
 from opentracing.ext import tags
+from packaging.version import Version
 from yarl import URL
 
 from faust.auth import (
@@ -95,6 +93,8 @@ __all__ = ["Consumer", "Producer", "Transport"]
 #         'Please install robinhood-aiokafka, not aiokafka')
 
 logger = get_logger(__name__)
+
+_AIOKAFKA_HAS_API_VERSION = Version(aiokafka.__version__) < Version("0.13.0")
 
 DEFAULT_GENERATION_ID = OffsetCommitRequest.DEFAULT_GENERATION_ID
 
@@ -514,6 +514,7 @@ class AIOKafkaConsumerThread(ConsumerThread):
         self._assignor = (
             self.app.assignor
             if self.app.conf.table_standby_replicas > 0
+            or bool(self.app.tables.changelog_topics)
             else RoundRobinPartitionAssignor
         )
         auth_settings = credentials_to_aiokafka_auth(
@@ -1513,7 +1514,7 @@ class Transport(base.Transport):
         for node_id in nodes:
             if node_id is None:
                 raise NotReady("Not connected to Kafka Broker")
-            request = MetadataRequest_v1([])
+            request = MetadataRequest([])
             wait_result = await owner.wait(
                 client.send(node_id, request),
                 timeout=timeout,
@@ -1546,7 +1547,6 @@ class Transport(base.Transport):
             owner.log.debug("Topic %r exists, skipping creation.", topic)
             return
 
-        protocol_version = 1
         extra_configs = config or {}
         config = self._topic_config(retention, compacting, deleting)
         config.update(extra_configs)
@@ -1563,7 +1563,7 @@ class Transport(base.Transport):
             else:
                 raise Exception("Controller node is None")
 
-        request = CreateTopicsRequest[protocol_version](
+        request = CreateTopicsRequest(
             [(topic, partitions, replication, [], list(config.items()))],
             timeout,
             False,

--- a/faust/transport/drivers/aiokafka.py
+++ b/faust/transport/drivers/aiokafka.py
@@ -27,6 +27,9 @@ from typing import (
 import aiokafka
 import aiokafka.abc
 import opentracing
+from packaging.version import Version
+
+_AIOKAFKA_HAS_API_VERSION = Version(aiokafka.__version__) < Version("0.13.0")
 from aiokafka import TopicPartition
 from aiokafka.consumer.group_coordinator import OffsetCommitRequest
 from aiokafka.coordinator.assignors.roundrobin import RoundRobinPartitionAssignor
@@ -529,8 +532,11 @@ class AIOKafkaConsumerThread(ConsumerThread):
                 f"broker_request_timeout={request_timeout}"
             )
 
+        consumer_kwargs: dict[str, Any] = {}
+        if _AIOKAFKA_HAS_API_VERSION:
+            consumer_kwargs["api_version"] = conf.consumer_api_version
         return aiokafka.AIOKafkaConsumer(
-            api_version=conf.consumer_api_version,
+            **consumer_kwargs,
             client_id=conf.broker_client_id,
             group_id=conf.id,
             group_instance_id=conf.consumer_group_instance_id,
@@ -1111,7 +1117,7 @@ class Producer(base.Producer):
 
     def _settings_default(self) -> Mapping[str, Any]:
         transport = cast(Transport, self.transport)
-        return {
+        settings: dict[str, Any] = {
             "bootstrap_servers": server_list(transport.url, transport.default_port),
             "client_id": self.client_id,
             "acks": self.acks,
@@ -1122,10 +1128,12 @@ class Producer(base.Producer):
             "security_protocol": "SSL" if self.ssl_context else "PLAINTEXT",
             "partitioner": self.partitioner,
             "request_timeout_ms": int(self.request_timeout * 1000),
-            "api_version": self._api_version,
             "metadata_max_age_ms": self.app.conf.producer_metadata_max_age_ms,
             "connections_max_idle_ms": self.app.conf.producer_connections_max_idle_ms,
         }
+        if _AIOKAFKA_HAS_API_VERSION:
+            settings["api_version"] = self._api_version
+        return settings
 
     def _settings_auth(self) -> Mapping[str, Any]:
         return credentials_to_aiokafka_auth(self.credentials, self.ssl_context)

--- a/faust/transport/drivers/aiokafka.py
+++ b/faust/transport/drivers/aiokafka.py
@@ -27,6 +27,9 @@ from typing import (
 import aiokafka
 import aiokafka.abc
 import opentracing
+from packaging.version import Version
+
+_AIOKAFKA_HAS_API_VERSION = Version(aiokafka.__version__) < Version("0.13.0")
 from aiokafka import TopicPartition
 from aiokafka.consumer.group_coordinator import OffsetCommitRequest
 from aiokafka.coordinator.assignors.roundrobin import RoundRobinPartitionAssignor

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -19,7 +19,6 @@ pytest<8
 python-dateutil>=2.8
 pytz>=2018.7
 bandit
-twine
 wheel
 intervaltree
 -r requirements.txt

--- a/tests/unit/transport/drivers/test_aiokafka.py
+++ b/tests/unit/transport/drivers/test_aiokafka.py
@@ -17,6 +17,7 @@ from opentracing.ext import tags
 import faust
 from faust import auth
 from faust.exceptions import ImproperlyConfigured, NotReady
+from faust.transport.drivers.aiokafka import _AIOKAFKA_HAS_API_VERSION
 from faust.sensors.monitor import Monitor
 from faust.transport.drivers import aiokafka as mod
 from faust.transport.drivers.aiokafka import (
@@ -813,8 +814,7 @@ class Test_AIOKafkaConsumerThread(AIOKafkaConsumerThreadFixtures):
             c = cthread._create_worker_consumer(transport)
             assert c is AIOKafkaConsumer.return_value
             max_poll_interval = conf.broker_max_poll_interval
-            AIOKafkaConsumer.assert_called_once_with(
-                api_version=app.conf.consumer_api_version,
+            expected_kwargs = dict(
                 client_id=conf.broker_client_id,
                 group_id=conf.id,
                 group_instance_id=conf.consumer_group_instance_id,
@@ -841,6 +841,9 @@ class Test_AIOKafkaConsumerThread(AIOKafkaConsumerThreadFixtures):
                 # flush_spans=cthread.flush_spans,
                 **auth_settings,
             )
+            if _AIOKAFKA_HAS_API_VERSION:
+                expected_kwargs["api_version"] = app.conf.consumer_api_version
+            AIOKafkaConsumer.assert_called_once_with(**expected_kwargs)
 
     def test__create_client_consumer(self, *, cthread, app):
         transport = cthread.transport
@@ -1382,7 +1385,7 @@ class ProducerBaseTest:
         with patch("aiokafka.AIOKafkaProducer") as AIOKafkaProducer:
             p = producer._new_producer()
             assert p is AIOKafkaProducer.return_value
-            AIOKafkaProducer.assert_called_once_with(
+            expected_kwargs = dict(
                 bootstrap_servers=bootstrap_servers,
                 client_id=client_id,
                 acks=acks,
@@ -1393,12 +1396,14 @@ class ProducerBaseTest:
                 security_protocol=security_protocol,
                 partitioner=producer.partitioner,
                 transactional_id=None,
-                api_version=api_version,
                 metadata_max_age_ms=metadata_max_age_ms,
                 connections_max_idle_ms=connections_max_idle_ms,
                 request_timeout_ms=request_timeout_ms,
                 **kwargs,
             )
+            if _AIOKAFKA_HAS_API_VERSION:
+                expected_kwargs["api_version"] = api_version
+            AIOKafkaProducer.assert_called_once_with(**expected_kwargs)
 
 
 class TestProducer(ProducerBaseTest):
@@ -1475,7 +1480,13 @@ class TestProducer(ProducerBaseTest):
         [
             pytest.param(
                 {"api_version": "auto"},
-                marks=pytest.mark.conf(producer_api_version="auto"),
+                marks=[
+                    pytest.mark.conf(producer_api_version="auto"),
+                    pytest.mark.skipif(
+                        not _AIOKAFKA_HAS_API_VERSION,
+                        reason="api_version removed in aiokafka>=0.13.0",
+                    ),
+                ],
             ),
             pytest.param({"acks": -1}, marks=pytest.mark.conf(producer_acks="all")),
             pytest.param(

--- a/tests/unit/transport/drivers/test_aiokafka.py
+++ b/tests/unit/transport/drivers/test_aiokafka.py
@@ -17,6 +17,7 @@ from opentracing.ext import tags
 import faust
 from faust import auth
 from faust.exceptions import ImproperlyConfigured, NotReady
+from faust.transport.drivers.aiokafka import _AIOKAFKA_HAS_API_VERSION
 from faust.sensors.monitor import Monitor
 from faust.transport.drivers import aiokafka as mod
 from faust.transport.drivers.aiokafka import (

--- a/tests/unit/transport/drivers/test_aiokafka.py
+++ b/tests/unit/transport/drivers/test_aiokafka.py
@@ -17,7 +17,6 @@ from opentracing.ext import tags
 import faust
 from faust import auth
 from faust.exceptions import ImproperlyConfigured, NotReady
-from faust.transport.drivers.aiokafka import _AIOKAFKA_HAS_API_VERSION
 from faust.sensors.monitor import Monitor
 from faust.transport.drivers import aiokafka as mod
 from faust.transport.drivers.aiokafka import (

--- a/tests/unit/transport/drivers/test_aiokafka.py
+++ b/tests/unit/transport/drivers/test_aiokafka.py
@@ -17,10 +17,10 @@ from opentracing.ext import tags
 import faust
 from faust import auth
 from faust.exceptions import ImproperlyConfigured, NotReady
-from faust.transport.drivers.aiokafka import _AIOKAFKA_HAS_API_VERSION
 from faust.sensors.monitor import Monitor
 from faust.transport.drivers import aiokafka as mod
 from faust.transport.drivers.aiokafka import (
+    _AIOKAFKA_HAS_API_VERSION,
     SLOW_PROCESSING_CAUSE_AGENT,
     SLOW_PROCESSING_CAUSE_STREAM,
     SLOW_PROCESSING_EXPLAINED,
@@ -795,6 +795,26 @@ class Test_AIOKafkaConsumerThread(AIOKafkaConsumerThreadFixtures):
             in_transaction=True,
             isolation_level="read_committed",
         )
+
+    def test__create_worker_consumer__uses_roundrobin_without_tables(
+        self, *, cthread, app
+    ):
+        app.conf.table_standby_replicas = 0
+        app.tables._changelogs.clear()
+        transport = cthread.transport
+        with patch("aiokafka.AIOKafkaConsumer"):
+            cthread._create_worker_consumer(transport)
+        assert cthread._assignor is mod.RoundRobinPartitionAssignor
+
+    def test__create_worker_consumer__uses_faust_assignor_with_changelog_topics(
+        self, *, cthread, app
+    ):
+        app.conf.table_standby_replicas = 0
+        app.tables._changelogs["app-foo-changelog"] = Mock(name="table")
+        transport = cthread.transport
+        with patch("aiokafka.AIOKafkaConsumer"):
+            cthread._create_worker_consumer(transport)
+        assert cthread._assignor is app.assignor
 
     def assert_create_worker_consumer(
         self,


### PR DESCRIPTION
## Description

- Force the usage of the `faust-assignor` if app uses `changelog_topics`.
- Use newest version of Kafka API-Requests for Metadata and Create Topic.

## Problems

- If `self.app.conf.table_standby_replicas = 0` the `RoundRobinPartitionAssignor` is used even is the app contains `changelog_topics`, which leads to a situation where `changelog_topics` are not consumed at the start of the app.

- With newer version of aiokafka, some older api-version where deprecated.

## Additional
This PR is based on the work of @nightcityblade (https://github.com/faust-streaming/faust/pull/674).